### PR TITLE
Fix slanting behavior for current glyph.

### DIFF
--- a/Slanter.roboFontExt/lib/slanter.py
+++ b/Slanter.roboFontExt/lib/slanter.py
@@ -235,9 +235,15 @@ class SlanterController(BaseWindowController):
         self._holdGlyphUpdates = True
         
         font = CurrentFont()
+        cGlyph = CurrentGlyph()
         attrValues = self.getAttributes()
         
-        for name in font.selection:
+        if font.selection:
+            gNames = font.selection
+        else:
+            gNames = [cGlyph.name]
+
+        for name in gNames:
             glyph = font[name]
             glyph.prepareUndo("Shifter")
             


### PR DESCRIPTION
Latest changes in RF make it so that the current glyph sometimes is not slanted when hitting “Apply”.
Instead, slant is added to the previously-active glyph.
