### PR TITLE
fixing repeated transformations in components [WIP]

### DIFF
--- a/Slanter.roboFontExt/lib/slanter.py
+++ b/Slanter.roboFontExt/lib/slanter.py
@@ -100,6 +100,8 @@ class SlanterController(BaseWindowController):
             for component in dest.components:
                 # get component center
                 _box = glyph.font[component.baseGlyph].bounds
+                if not _box:
+                    continue
                 _cx = _box[0] + (_box[2] - _box[0]) * .5
                 _cy = _box[1] + (_box[3] - _box[1]) * .5
                 # calculate origin in relation to base glyph

--- a/Slanter.roboFontExt/lib/slanter.py
+++ b/Slanter.roboFontExt/lib/slanter.py
@@ -56,7 +56,7 @@ class SlanterController(BaseWindowController):
 
         if not addComponents:
             for component in dest.components:
-                pointPen = DecomposePointPen(glyph.font, dest.getPointPen(), component.transformation)
+                pointPen = DecomposePointPen(glyph.layer, dest.getPointPen(), component.transformation)
                 component.drawPoints(pointPen)
                 dest.removeComponent(component)
 
@@ -99,7 +99,7 @@ class SlanterController(BaseWindowController):
             # this seems to work !!!
             for component in dest.components:
                 # get component center
-                _box = glyph.font[component.baseGlyph].bounds
+                _box = glyph.layer[component.baseGlyph].bounds
                 if not _box:
                     continue
                 _cx = _box[0] + (_box[2] - _box[0]) * .5

--- a/Slanter.roboFontExt/lib/slanter.py
+++ b/Slanter.roboFontExt/lib/slanter.py
@@ -3,19 +3,13 @@ from defconAppKit.windows.baseWindow import BaseWindowController
 
 from mojo.glyphPreview import GlyphPreview
 from mojo.events import addObserver, removeObserver
-from mojo.roboFont import CurrentGlyph, CurrentFont, RGlyph, OpenWindow, version, RPoint
-from mojo.UI import AllSpaceCenters, CurrentGlyphWindow, getDefault
+from mojo.roboFont import CurrentGlyph, CurrentFont, RGlyph, RPoint, OpenWindow
+from mojo.UI import AllSpaceCenters, CurrentGlyphWindow, SliderEditStepper, getDefault
+from mojo.pens import DecomposePointPen
 import mojo.drawingTools as drawingTools
 
-if version >= "3.0":
-    from mojo.UI import SliderEditStepper as SliderEditIntStepper
-    from mojo.pens import DecomposePointPen
-else:
-    from lib.UI.stepper import SliderEditIntStepper
-    from lib.fontObjects.doodleComponent import DecomposePointPen
-
 from fontTools.misc.transform import Transform
-from math import radians, sin, cos
+from math import radians
 
 
 def camelCase(txt):
@@ -23,7 +17,7 @@ def camelCase(txt):
     return txt[0].lower() + txt[1:]
 
 
-class SliderEditFloatStepper(SliderEditIntStepper):
+class SliderEditFloatStepper(SliderEditStepper):
 
     multiplier = 100.0
 
@@ -62,8 +56,7 @@ class SlanterController(BaseWindowController):
 
         if not addComponents:
             for component in dest.components:
-                glyphSet = glyph.font if version >= "3.0" else glyph.getParent()
-                pointPen = DecomposePointPen(glyphSet, dest.getPointPen(), component.transformation)
+                pointPen = DecomposePointPen(glyph.font, dest.getPointPen(), component.transformation)
                 component.drawPoints(pointPen)
                 dest.removeComponent(component)
 
@@ -88,7 +81,7 @@ class SlanterController(BaseWindowController):
                     bPoint.anchorLabels = ["extremePoint"]
 
         cx, cy = 0, 0
-        box = glyph.bounds if version >= "3.0" else glyph.box
+        box = glyph.bounds
         if box:
             cx = box[0] + (box[2] - box[0]) * .5
             cy = box[1] + (box[3] - box[1]) * .5
@@ -97,38 +90,31 @@ class SlanterController(BaseWindowController):
         t = t.skew(skew)
         t = t.translate(cx, cy).rotate(rotation).translate(-cx, -cy)
 
-        # RF3
-        if version >= "3.0":
-            if not skipComponents:
-                dest.transformBy(tuple(t))
-            else:
-                for contour in dest.contours:
-                    contour.transformBy(tuple(t))
-
-                # this seems to work !!!
-                for component in dest.components:
-                    # get component center
-                    _box = glyph.font[component.baseGlyph].bounds
-                    _cx = _box[0] + (_box[2] - _box[0]) * .5
-                    _cy = _box[1] + (_box[3] - _box[1]) * .5
-                    # calculate origin in relation to base glyph
-                    dx = cx - _cx
-                    dy = cy - _cy
-                    # create transformation matrix
-                    tt = Transform()
-                    tt = tt.skew(skew)
-                    tt = tt.translate(dx, dy).rotate(rotation).translate(-dx, -dy)
-                    # apply transformation matrix to component offset
-                    P = RPoint()
-                    P.position = component.offset
-                    P.transformBy(tuple(tt))
-                    # set component offset position
-                    component.offset = P.position
-
-        # RF1
+        if not skipComponents:
+            dest.transformBy(tuple(t))
         else:
-            dest.transform(t)
-            # do the same as above for RF1
+            for contour in dest.contours:
+                contour.transformBy(tuple(t))
+
+            # this seems to work !!!
+            for component in dest.components:
+                # get component center
+                _box = glyph.font[component.baseGlyph].bounds
+                _cx = _box[0] + (_box[2] - _box[0]) * .5
+                _cy = _box[1] + (_box[3] - _box[1]) * .5
+                # calculate origin in relation to base glyph
+                dx = cx - _cx
+                dy = cy - _cy
+                # create transformation matrix
+                tt = Transform()
+                tt = tt.skew(skew)
+                tt = tt.translate(dx, dy).rotate(rotation).translate(-dx, -dy)
+                # apply transformation matrix to component offset
+                P = RPoint()
+                P.position = component.offset
+                P.transformBy(tuple(tt))
+                # set component offset position
+                component.offset = P.position
 
         dest.extremePoints(round=0)
         for contour in dest:
@@ -280,7 +266,7 @@ class SlanterController(BaseWindowController):
         if CurrentGlyphWindow():
             selection = [CurrentGlyph().name]
         else:
-            selection = font.selectedGlyphNames if version >= "3.0" else font.selection
+            selection = font.selectedGlyphNames
 
         for name in selection:
             glyph = font[name]
@@ -296,11 +282,7 @@ class SlanterController(BaseWindowController):
     def generateFontCallback(self, sender):
         progress = self.startProgress("Generating Shifters...")
         font = CurrentFont()
-        if version >= "3.0":
-            outFont = RFont(showInterface=False)
-        else:
-            outFont = RFont(showUI=False)
-            
+        outFont = RFont(showInterface=False)
         outFont.info.update(font.info.asDict())
         outFont.features.text = font.features.text
 
@@ -315,10 +297,7 @@ class SlanterController(BaseWindowController):
 
         progress.close()
 
-        if version >= "3.0":
-            outFont.openInterface()
-        else:
-            outFont.showUI()
+        outFont.openInterface()
 
     def windowClose(self, sender):
         self.unsubscribeGlyph()


### PR DESCRIPTION
this is an attempt to fix the problem described in [Slanter double and triple slanting components](https://forum.robofont.com/topic/882/slanter-double-and-triple-slanting-components/6).  
also includes some syntax updates for RF3 / FontParts

still needs some work:

- components with rotations are off (se for example glyphs with caron in RoboType Roman)
- slant selected glyphs with the *Apply Glyphs* button not fixed yet
